### PR TITLE
fix sign_tx len(witness) -> hex(len(witness))

### DIFF
--- a/ckb_toolkit/core/signer.py
+++ b/ckb_toolkit/core/signer.py
@@ -22,7 +22,7 @@ def sign_tx(tx: Transaction, private_key: HexBytes) -> Transaction:
     witnesses = tx['witnesses'][1:]
     for witness in witnesses:
         len_buffer = bytearray()
-        extend_uint64(len_buffer, len(witness))
+        extend_uint64(len_buffer, hex(len(witness)))
         hasher.update(len_buffer)
         hasher.update(hex_to_bytes(witnesses))
 


### PR DESCRIPTION
这里直接len()是十进制，使更深处无法int(int, 0)
这里再套一个 hex即可